### PR TITLE
朝の挨拶のメッセージ出力コマンドの実装

### DIFF
--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -2,7 +2,12 @@ module Ruboty
   module Actions
     class GreetingAtMorning < Base
       def call
-        message.reply("hoge")
+        greetings = Sebastian::Settings.greeting_at_morning
+
+        now  = Time.new
+        week = ["日", "月", "火", "水", "木", "金", "土"]
+
+        message.reply(sprintf(greetings.header, now.month, now.day, week[now.wday])) # 一言目
       end
     end
   end

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -2,10 +2,15 @@ module Ruboty
   module Actions
     class GreetingAtMorning < Base
       def call
-        now  = Time.new
+        now  = Time.now
         week = ["日", "月", "火", "水", "木", "金", "土"]
 
-        message.reply(sprintf(greetings.header, now.month, now.day, week[now.wday])) # 一言目
+        # 一言目
+        if now.month == 1 && now.day == 1
+          message.reply(sprintf(greetings.first_of_year.header, now.year))
+        else
+          message.reply(sprintf(greetings.header, now.month, now.day, week[now.wday]))
+        end
       end
 
       def greetings

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -16,8 +16,8 @@ module Ruboty
         tokyodome_event = "" # 後日実装するメソッドからイベントを取得する
         cityhall_event  = "" # 後日実装するメソッドからイベントを取得する
 
-        message.reply(sprintf(greetings.tokyodome.message, "【球団戦】", "球団1 - 球団2")) if tokyodome_event
-        message.reply(sprintf(greetings.cityhall.message,  "イベント名", "詳細URL")) if cityhall_event
+        message.reply(greetings.tokyodome.message % ["【球団戦】", "球団1 - 球団2"]) if tokyodome_event
+        message.reply(greetings.cityhall.message  % ["イベント名", "詳細URL"]) if cityhall_event
 
         # 三言目
         if "実行年の最終出社日である"

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -44,7 +44,7 @@ module Ruboty
         last_day = 28 if last.saturday?
         last_day ||= 29
 
-        now.month == 12 && now.day == last_day ? true : false
+        now.month == 12 && now.day == last_day
       end
 
       def first_of_year?
@@ -54,7 +54,7 @@ module Ruboty
         first_day = 6 if first.saturday?
         first_day ||= 5
 
-        now.month == 1 && now.day == first_day ? true : false
+        now.month == 1 && now.day == first_day
       end
     end
   end

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -35,7 +35,7 @@ module Ruboty
       end
 
       def last_of_year?(now)
-        weekday = Time.new(now.year, 12, 29).mday
+        weekday = Time.new(now.year, 12, 29).wday
 
         case weekday
         when 0
@@ -50,7 +50,7 @@ module Ruboty
       end
 
       def first_of_year?
-
+        
       end
     end
   end

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -2,12 +2,14 @@ module Ruboty
   module Actions
     class GreetingAtMorning < Base
       def call
-        greetings = Sebastian::Settings.greeting_at_morning
-
         now  = Time.new
         week = ["日", "月", "火", "水", "木", "金", "土"]
 
         message.reply(sprintf(greetings.header, now.month, now.day, week[now.wday])) # 一言目
+      end
+
+      def greetings
+        @messages ||= Sebastian::Settings.greeting_at_morning
       end
     end
   end

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -36,6 +36,9 @@ module Ruboty
 
       def last_of_year?
       end
+
+      def first_of_year?
+      end
     end
   end
 end

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -7,9 +7,9 @@ module Ruboty
 
         # 一言目
         if first_of_year?(now)
-          message.reply(sprintf(greetings.first_of_year.header, now.year))
+          message.reply(greetings.first_of_year.header % now.year)
         else
-          message.reply(sprintf(greetings.header, now.month, now.day, week[now.wday]))
+          message.reply(greetings.header % [now.month, now.day, week[now.wday]])
         end
 
         #️ 二言目
@@ -50,15 +50,15 @@ module Ruboty
       end
 
       def first_of_year?(now)
-        p weekday = Time.new(now.year, 1, 5).wday
+        weekday = Time.new(now.year, 1, 5).wday
 
         case weekday
         when 0
-          p first_day = 7
+          first_day = 7
         when 6
-          p first_day = 6
+          first_day = 6
         else
-          p first_day = 5
+          first_day = 5
         end
 
         now.month == 1 && now.day == first_day ? true : false

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -34,10 +34,23 @@ module Ruboty
         @messages ||= Sebastian::Settings.greeting_at_morning
       end
 
-      def last_of_year?
+      def last_of_year?(now)
+        weekday = Time.new(now.year, 12, 29).mday
+
+        case weekday
+        when 0
+          last_day = 27
+        when 6
+          last_day = 28
+        else
+          last_day = 29
+        end
+
+        now.month == 12 && now.day == last_day ? true : false
       end
 
       def first_of_year?
+
       end
     end
   end

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -11,6 +11,13 @@ module Ruboty
         else
           message.reply(sprintf(greetings.header, now.month, now.day, week[now.wday]))
         end
+
+        #️ 二言目
+        tokyodome_event = "" # 後日実装するメソッドからイベントを取得する
+        cityhall_event  = "" # 後日実装するメソッドからイベントを取得する
+
+        message.reply(sprintf(greetings.tokyodome.message, "【球団戦】", "球団1 - 球団2")) if tokyodome_event
+        message.reply(sprintf(greetings.cityhall.message,  "イベント名", "詳細URL")) if cityhall_event
       end
 
       def greetings

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -11,7 +11,7 @@ module Ruboty
           message.reply(greetings.header % [now.month, now.day, week[now.wday]])
         end
 
-        #️ 二言目
+        # 二言目
         tokyodome_event = nil # 後日実装するメソッドからイベントを取得する
         cityhall_event  = nil # 後日実装するメソッドからイベントを取得する
 

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -33,6 +33,9 @@ module Ruboty
       def greetings
         @messages ||= Sebastian::Settings.greeting_at_morning
       end
+
+      def last_of_year?
+      end
     end
   end
 end

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -29,6 +29,7 @@ module Ruboty
         end
       end
 
+      private
       def greetings
         @messages ||= Sebastian::Settings.greeting_at_morning
       end

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -6,7 +6,7 @@ module Ruboty
         week = ["日", "月", "火", "水", "木", "金", "土"]
 
         # 一言目
-        if now.month == 1 && now.day == 1
+        if first_of_year?(now)
           message.reply(sprintf(greetings.first_of_year.header, now.year))
         else
           message.reply(sprintf(greetings.header, now.month, now.day, week[now.wday]))
@@ -20,9 +20,9 @@ module Ruboty
         message.reply(greetings.cityhall.message  % ["イベント名", "詳細URL"]) if cityhall_event
 
         # 三言目
-        if "実行年の最終出社日である"
+        if last_of_year?(now)
           greetings.last_of_year.footer.each {|mes| message.reply(mes)}
-        elsif now.month == 1 && now.day == 1
+        elsif first_of_year?(now)
           message.reply(greetings.first_of_year.footer)
         else
           message.reply(greetings.footer)

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -49,8 +49,19 @@ module Ruboty
         now.month == 12 && now.day == last_day ? true : false
       end
 
-      def first_of_year?
-        
+      def first_of_year?(now)
+        p weekday = Time.new(now.year, 1, 5).wday
+
+        case weekday
+        when 0
+          p first_day = 7
+        when 6
+          p first_day = 6
+        else
+          p first_day = 5
+        end
+
+        now.month == 1 && now.day == first_day ? true : false
       end
     end
   end

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -38,31 +38,21 @@ module Ruboty
       end
 
       def last_of_year?
-        weekday = Time.new(now.year, 12, 29).wday
+        last = Time.new(now.year, 12, 29)
 
-        case weekday
-        when 0
-          last_day = 27
-        when 6
-          last_day = 28
-        else
-          last_day = 29
-        end
+        last_day = 27 if last.sunday?
+        last_day = 28 if last.saturday?
+        last_day ||= 29
 
         now.month == 12 && now.day == last_day ? true : false
       end
 
       def first_of_year?
-        weekday = Time.new(now.year, 1, 5).wday
+        first = Time.new(now.year, 1, 5)
 
-        case weekday
-        when 0
-          first_day = 7
-        when 6
-          first_day = 6
-        else
-          first_day = 5
-        end
+        first_day = 7 if first.sunday?
+        first_day = 6 if first.saturday?
+        first_day ||= 5
 
         now.month == 1 && now.day == first_day ? true : false
       end

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -12,8 +12,8 @@ module Ruboty
         end
 
         #️ 二言目
-        tokyodome_event = "" # 後日実装するメソッドからイベントを取得する
-        cityhall_event  = "" # 後日実装するメソッドからイベントを取得する
+        tokyodome_event = nil # 後日実装するメソッドからイベントを取得する
+        cityhall_event  = nil # 後日実装するメソッドからイベントを取得する
 
         message.reply(greetings.tokyodome.message % ["【球団戦】", "球団1 - 球団2"]) if tokyodome_event
         message.reply(greetings.cityhall.message  % ["イベント名", "詳細URL"]) if cityhall_event

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -21,7 +21,7 @@ module Ruboty
         # 三言目
         if last_of_year?
           greetings.last_of_year.footer.each {|mes| message.reply(mes)}
-        elsif first_of_year?(now)
+        elsif first_of_year?
           message.reply(greetings.first_of_year.footer)
         else
           message.reply(greetings.footer)

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -2,11 +2,10 @@ module Ruboty
   module Actions
     class GreetingAtMorning < Base
       def call
-        now  = Time.now
         week = ["日", "月", "火", "水", "木", "金", "土"]
 
         # 一言目
-        if first_of_year?(now)
+        if first_of_year?
           message.reply(greetings.first_of_year.header % now.year)
         else
           message.reply(greetings.header % [now.month, now.day, week[now.wday]])
@@ -20,7 +19,7 @@ module Ruboty
         message.reply(greetings.cityhall.message  % ["イベント名", "詳細URL"]) if cityhall_event
 
         # 三言目
-        if last_of_year?(now)
+        if last_of_year?
           greetings.last_of_year.footer.each {|mes| message.reply(mes)}
         elsif first_of_year?(now)
           message.reply(greetings.first_of_year.footer)
@@ -34,7 +33,11 @@ module Ruboty
         @messages ||= Sebastian::Settings.greeting_at_morning
       end
 
-      def last_of_year?(now)
+      def now
+        @now ||= Time.now
+      end
+
+      def last_of_year?
         weekday = Time.new(now.year, 12, 29).wday
 
         case weekday
@@ -49,7 +52,7 @@ module Ruboty
         now.month == 12 && now.day == last_day ? true : false
       end
 
-      def first_of_year?(now)
+      def first_of_year?
         weekday = Time.new(now.year, 1, 5).wday
 
         case weekday

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -18,6 +18,15 @@ module Ruboty
 
         message.reply(sprintf(greetings.tokyodome.message, "【球団戦】", "球団1 - 球団2")) if tokyodome_event
         message.reply(sprintf(greetings.cityhall.message,  "イベント名", "詳細URL")) if cityhall_event
+
+        # 三言目
+        if "実行年の最終出社日である"
+          greetings.last_of_year.footer.each {|mes| message.reply(mes)}
+        elsif now.month == 1 && now.day == 1
+          message.reply(greetings.first_of_year.footer)
+        else
+          message.reply(greetings.footer)
+        end
       end
 
       def greetings


### PR DESCRIPTION
## PRの目的

朝の挨拶のメッセージを出力するコマンドの実装を目的とします。
## 実装内容

"ruboty greet morning"と打つことで朝の挨拶のメッセージを出力する。
メッセージは下記の通り構成される。
#### 1行目：次のどちらかのメッセージを出力（日付は現在日時）
##### 通常時：

"おはようございます。x月x日x曜日でございます。"
##### 仕事初め(1月5, 6, 7日のいずれか)：

"あけましておめでとうございます。新しい年を迎えることができまして、大変喜ばしく思います。%d年でございます。"
#### 2行目：東京ドーム、シティホールの予定を発言する。

※予定がない場合は発言しない

"東京ドームでは %1$s %2$s が開催されますので、お出かけの際はご注意ください。"
"東京ドームシティホールでは %1$s が開催されますので、お出かけの際はご注意ください。詳細は %2$s をご覧下さい。"
#### 3行目：次のいずれかのメッセージを出力
##### 通常時：

"本日もどうぞよろしくお願いいたします。"
##### 最終出社日(12月26, 27, 28日のいずれか)：

"今年の出勤日も本日が最後となりました。わたくしの今年の業務も、この通知で終了でございます。一年間お疲れ様でございました。良いお年をお迎えください。"
##### 仕事初め(1月5, 6, 7日のいずれか)：

"今年もまた一年、どうぞよろしくお願いいたします。"
## 特に見てほしい箇所

条件分岐の処理や、sprintfを使った文字の埋め込みの処理に問題がないか確認をお願いします。
## 未実装箇所について

文言が堅い件の修正と、祝日判定、イベント取得ロジックは別なPRで実装する予定です。
最終出社日のロジックは可能であれば今回のPRで実装できればなと考えています。
