### PR TITLE
定時前を知らせるメッセージ出力コマンドの実装

### DIFF
--- a/lib/ruboty/actions/greeting_before_closing.rb
+++ b/lib/ruboty/actions/greeting_before_closing.rb
@@ -4,6 +4,11 @@ module Ruboty
       def call
         message.reply("hoge")
       end
+
+      private
+      def greetings
+        @messages ||= Sebastian::Settings.greeting_before_closing
+      end
     end
   end
 end

--- a/lib/ruboty/actions/greeting_before_closing.rb
+++ b/lib/ruboty/actions/greeting_before_closing.rb
@@ -7,6 +7,13 @@ module Ruboty
 
         # 二言目
         message.reply(greetings.middle)
+
+        # 三言目
+        tokyodome_event = "" # 後日実装するメソッドからイベントを取得する
+        cityhall_event  = "" # 後日実装するメソッドからイベントを取得する
+
+        message.reply(sprintf(greetings.tokyodome.message, "【球団戦】", "球団1 - 球団2")) if tokyodome_event
+        message.reply(sprintf(greetings.cityhall.message,  "イベント名", "詳細URL")) if cityhall_event
       end
 
       private

--- a/lib/ruboty/actions/greeting_before_closing.rb
+++ b/lib/ruboty/actions/greeting_before_closing.rb
@@ -12,8 +12,8 @@ module Ruboty
         tokyodome_event = "" # 後日実装するメソッドからイベントを取得する
         cityhall_event  = "" # 後日実装するメソッドからイベントを取得する
 
-        message.reply(sprintf(greetings.tokyodome.message, "【球団戦】", "球団1 - 球団2")) if tokyodome_event
-        message.reply(sprintf(greetings.cityhall.message,  "イベント名", "詳細URL")) if cityhall_event
+        message.reply(greetings.tokyodome.message % ["【球団戦】", "球団1 - 球団2"]) if tokyodome_event
+        message.reply(greetings.cityhall.message % ["イベント名", "詳細URL"]) if cityhall_event
       end
 
       private

--- a/lib/ruboty/actions/greeting_before_closing.rb
+++ b/lib/ruboty/actions/greeting_before_closing.rb
@@ -4,6 +4,9 @@ module Ruboty
       def call
         # 一言目
         message.reply(greetings.header.sample)
+
+        # 二言目
+        message.reply(greetings.middle)
       end
 
       private

--- a/lib/ruboty/actions/greeting_before_closing.rb
+++ b/lib/ruboty/actions/greeting_before_closing.rb
@@ -2,7 +2,8 @@ module Ruboty
   module Actions
     class GreetingBeforeClosing < Base
       def call
-        message.reply("hoge")
+        # 一言目
+        message.reply(greetings.header.sample)
       end
 
       private

--- a/lib/ruboty/actions/greeting_before_closing.rb
+++ b/lib/ruboty/actions/greeting_before_closing.rb
@@ -9,11 +9,11 @@ module Ruboty
         message.reply(greetings.middle)
 
         # 三言目
-        tokyodome_event = "" # 後日実装するメソッドからイベントを取得する
-        cityhall_event  = "" # 後日実装するメソッドからイベントを取得する
+        tokyodome_event = nil # 後日実装するメソッドからイベントを取得する
+        cityhall_event  = nil # 後日実装するメソッドからイベントを取得する
 
         message.reply(greetings.tokyodome.message % ["【球団戦】", "球団1 - 球団2"]) if tokyodome_event
-        message.reply(greetings.cityhall.message % ["イベント名", "詳細URL"]) if cityhall_event
+        message.reply(greetings.cityhall.message  % ["イベント名", "詳細URL"]) if cityhall_event
       end
 
       private


### PR DESCRIPTION
## PRの目的

定時前を知らせるメッセージを出力するコマンドの実装を目的とします。
## 実装内容

"ruboty greet before close"と打つことで定時前を知らせるメッセージを出力する。
メッセージは下記の通り構成される。
#### 1行目：次のどちらかのメッセージを出力

"まもなく19時、業務終了のお時間でございます。"
"まもなく業務終了のお時間でございます。"
"業務終了のお時間がせまっております。"
#### 2行目：次のメッセージを出力

"お帰りの前に本日のお仕事を振り返るのはいかがでしょうか。\nhttps://feedforce.qiita.com/"
#### 3行目：次のいずれかのメッセージを出力

※予定がない場合は発言しない

"東京ドームでは`[開始時間]` `[イベント名]`が開催されますので、お出かけの際はご注意ください。"
"東京ドームシティホールでは`[イベント名]`が開催されますので、お出かけの際はご注意ください。詳細は`[詳細URL]`をご覧下さい。"
## 特に見てほしい箇所

処理の流れに問題がないか確認をお願いします。
## 未実装箇所について

別PRで実装予定のもの
- 文言が堅い件の修正
- 祝日判定ロジック
- イベント取得ロジック
