### PR TITLE
settingslogicの使用に関する修正

### DIFF
--- a/lib/ruboty/sebastian.rb
+++ b/lib/ruboty/sebastian.rb
@@ -3,6 +3,7 @@ require "ruboty/actions/greeting_at_morning"
 require "ruboty/actions/greeting_before_closing"
 require "ruboty/actions/greeting_at_closing"
 require "ruboty/handlers/sebastian"
+require "settingslogic"
 
 module Ruboty
   module Sebastian

--- a/ruboty-sebastian.gemspec
+++ b/ruboty-sebastian.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "ruboty"
+  spec.add_dependency "settingslogic"
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
 


### PR DESCRIPTION
# 修正した箇所
- /lib/ruboty/sebastian.rb内で`settingslogic`をrequireする処理の記述漏れを修正
- gem specのadd_dependencyに`settings logic`が記述されていなかった点を修正
