### PR TITLE
Remove `gem` from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'settingslogic'
-# Specify your gem's dependencies in ruboty-sebastian.gemspec
 gemspec


### PR DESCRIPTION
settingslogicの依存は、ruboty-sebastian.gemspecに書いてあるから不要と思ったのでPR出してみました
