### PR TITLE
gemspecにnokogiriを追加

### DIFF
--- a/ruboty-sebastian.gemspec
+++ b/ruboty-sebastian.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "ruboty"
   spec.add_dependency "settingslogic"
+  spec.add_dependency "nokogiri"
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
 


### PR DESCRIPTION
## 目的

イベント取得で使用するnokogiriをgemspecに追加します。
