### PR TITLE
TokyoDomeEventモジュールにnowメソッドを追加

### DIFF
--- a/lib/ruboty/actions/get_event.rb
+++ b/lib/ruboty/actions/get_event.rb
@@ -2,7 +2,7 @@ require 'open-uri'
 require 'nokogiri'
  
 module TokyoDomeEvent 
-  def get_event_from_cityhall(now)
+  def get_event_from_cityhall
     url = "http://www.tokyo-dome.co.jp/tdc-hall/event/"
     doc = Nokogiri::HTML.parse(open(url).read.force_encoding('UTF-8'))
 
@@ -20,7 +20,7 @@ module TokyoDomeEvent
     {title: title, url: url+fragment}
   end
  
-  def get_event_from_dome(now)
+  def get_event_from_dome
     url = "http://www.tokyo-dome.co.jp/dome/schedule/"
     doc = Nokogiri::HTML.parse(open(url).read.force_encoding('UTF-8'))
 
@@ -36,5 +36,9 @@ module TokyoDomeEvent
     end
     
     {title: title, vs: vs}
+  end
+
+  def now
+    @now ||= Time.now
   end
 end

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -14,8 +14,8 @@ module Ruboty
         end
 
         # 二言目
-        tokyodome = get_event_from_dome(now)
-        cityhall  = get_event_from_cityhall(now)
+        tokyodome = get_event_from_dome
+        cityhall  = get_event_from_cityhall
 
         message.reply(greetings.tokyodome.message % tokyodome) if tokyodome
         message.reply(greetings.cityhall.message  % cityhall)  if cityhall

--- a/lib/ruboty/actions/greeting_at_morning.rb
+++ b/lib/ruboty/actions/greeting_at_morning.rb
@@ -35,10 +35,6 @@ module Ruboty
         @messages ||= Sebastian::Settings.greeting_at_morning
       end
 
-      def now
-        @now ||= Time.now
-      end
-
       def last_of_year?
         last = Time.new(now.year, 12, 29)
 


### PR DESCRIPTION
## 目的

TokyoDomeEventモジュールに現在日時を格納するnowメソッドを実装します。
それに伴い、
- 現在日時を格納していたGreetingAtMorning#nowの削除
- TokyoDomeEvent#get_event_from...から引数を削除
  の変更を行いました。
## 理由
- TokyoDomeEvent#get_event_from...を呼び出す際に引数なしでシンプルに呼び出せる
- TokyoDomeEventモジュールをincludeしたクラスからnowメソッドを呼び出せる
- 今後GreetingAtBeforeClosingクラスでイベント情報を取得する際に簡単に記述できる
