### PR TITLE
unless文を使った表記からif文を使った表記に変更

### DIFF
--- a/lib/ruboty/actions/get_event.rb
+++ b/lib/ruboty/actions/get_event.rb
@@ -10,12 +10,9 @@ module TokyoDomeEvent
     return if column.empty?
 
     title = column.text.strip
+    return if title.empty? || title == "【reserved】"
 
-    unless title.empty? || title == "【reserved】"
-      fragment = column.attribute("href").value
-    else
-      return
-    end
+    fragment = column.attribute("href").value
 
     {title: title, url: url+fragment}
   end


### PR DESCRIPTION
## 目的

unless文を使った表記が見辛いという指摘を受けたため、
if文を使った直感的な表現に変更
## 変更内容

従来までは

```
unless 条件1 || 条件2
　処理1
else
　return
end
```

となっていた箇所を、

```
return if 条件1 || 条件2
処理1
```

という表記に変更しました。
