### PR TITLE
定時前のメッセージ出力機能にイベント取得ロジックの埋め込み

### DIFF
--- a/lib/ruboty/actions/greeting_before_closing.rb
+++ b/lib/ruboty/actions/greeting_before_closing.rb
@@ -11,11 +11,11 @@ module Ruboty
         message.reply(greetings.middle)
 
         # 三言目
-        tokyodome_event = nil # 後日実装するメソッドからイベントを取得する
-        cityhall_event  = nil # 後日実装するメソッドからイベントを取得する
+        tokyodome = get_event_from_dome(now)
+        cityhall  = get_event_from_cityhall(now)
 
-        message.reply(greetings.tokyodome.message % ["【球団戦】", "球団1 - 球団2"]) if tokyodome_event
-        message.reply(greetings.cityhall.message  % ["イベント名", "詳細URL"]) if cityhall_event
+        message.reply(greetings.tokyodome.message % tokyodome) if tokyodome
+        message.reply(greetings.cityhall.message  % cityhall)  if cityhall
       end
 
       private

--- a/lib/ruboty/actions/greeting_before_closing.rb
+++ b/lib/ruboty/actions/greeting_before_closing.rb
@@ -1,6 +1,8 @@
 module Ruboty
   module Actions
     class GreetingBeforeClosing < Base
+      include TokyoDomeEvent
+
       def call
         # 一言目
         message.reply(greetings.header.sample)

--- a/lib/ruboty/actions/greeting_before_closing.rb
+++ b/lib/ruboty/actions/greeting_before_closing.rb
@@ -11,8 +11,8 @@ module Ruboty
         message.reply(greetings.middle)
 
         # 三言目
-        tokyodome = get_event_from_dome(now)
-        cityhall  = get_event_from_cityhall(now)
+        tokyodome = get_event_from_dome
+        cityhall  = get_event_from_cityhall
 
         message.reply(greetings.tokyodome.message % tokyodome) if tokyodome
         message.reply(greetings.cityhall.message  % cityhall)  if cityhall


### PR DESCRIPTION
## 目的

GreetingBeforeClosingクラスにTokyoDomeEventモジュールをincludeして、定時前のメッセージ出力機能にイベント取得ロジックの埋め込みを行います。
## 実装内容
- GreetingBeforeClosingクラスにTokyoDomeEventモジュールをinclude
- 取得したイベント情報をメッセージに埋め込む処理の追加
## 動作確認

`ruboty greet before close`と打つことで実行日時の定時前のメッセージが出力されます。
※ 任意の日時で実行したい場合はget_event.rbのnowメソッド内に任意のTimeインスタンスを設定してください。

``` rb
# 例
def now
  Time.new(2015, 6, 7)
end
```
