### PR TITLE
/lib/ruboty/sebastian.rbにrubotyをrequireするよう追記

### DIFF
--- a/lib/ruboty/sebastian.rb
+++ b/lib/ruboty/sebastian.rb
@@ -1,3 +1,4 @@
+require "ruboty"
 require "ruboty/sebastian/version"
 require "ruboty/actions/get_event"
 require "ruboty/actions/greeting_at_morning"


### PR DESCRIPTION
# 目的

ruboty-sebastianはそもそもruboty上で動くプラグインであるため、rubotyをrequireするよう追記。
動作上は問題なかったが、デバッグの際にエラーが出ることがあった。
# 概要

lib/ruboty/sebastian.rbに`require "ruboty"` を追記。
