### PR TITLE
東京ドームのほかの日のイベントをお知らせしてしまう件

### DIFF
--- a/lib/ruboty/actions/get_event.rb
+++ b/lib/ruboty/actions/get_event.rb
@@ -22,7 +22,7 @@ module TokyoDomeEvent
     doc = Nokogiri::HTML.parse(open(url).read.force_encoding('UTF-8'))
 
     column = doc.xpath("//th[contains(./text(), '#{now.day}日')]/..").
-      select{|c| c.xpath("./th").text.strip.match(/\A#{now.day}日/) }.
+      select{|c| c.xpath("./th").text.strip.start_with?("#{now.day}日") }.
       first.xpath("./td//p")
     return if column.empty?
 

--- a/lib/ruboty/actions/get_event.rb
+++ b/lib/ruboty/actions/get_event.rb
@@ -1,7 +1,7 @@
 require 'open-uri'
 require 'nokogiri'
- 
-module TokyoDomeEvent 
+
+module TokyoDomeEvent
   def get_event_from_cityhall
     url = "http://www.tokyo-dome.co.jp/tdc-hall/event/"
     doc = Nokogiri::HTML.parse(open(url).read.force_encoding('UTF-8'))
@@ -16,7 +16,7 @@ module TokyoDomeEvent
 
     {title: title, url: url+fragment}
   end
- 
+
   def get_event_from_dome
     url = "http://www.tokyo-dome.co.jp/dome/schedule/"
     doc = Nokogiri::HTML.parse(open(url).read.force_encoding('UTF-8'))
@@ -33,7 +33,7 @@ module TokyoDomeEvent
       title = column[0].children.attribute('alt').value.strip
       vs = column[1].children.text.strip
     end
-    
+
     {title: title, vs: vs}
   end
 

--- a/lib/ruboty/actions/get_event.rb
+++ b/lib/ruboty/actions/get_event.rb
@@ -21,7 +21,9 @@ module TokyoDomeEvent
     url = "http://www.tokyo-dome.co.jp/dome/schedule/"
     doc = Nokogiri::HTML.parse(open(url).read.force_encoding('UTF-8'))
 
-    column = doc.xpath("//th[contains(./text(), '#{now.day}日')]/following-sibling::*").xpath(".//p")
+    column = doc.xpath("//th[contains(./text(), '#{now.day}日')]/..").
+      select{|c| c.xpath("./th").text.strip.match(/\A#{now.day}日/) }.
+      first.xpath("./td//p")
     return if column.empty?
 
     if column[0].children.search('img').empty?


### PR DESCRIPTION
### 事象

8/6 に 8/16 のイベントをお知らせしていた。
### 問題
- 日付が一桁 (1日〜9日) の時
- 当日のイベントがなく
- 同じ月の一の位の数が同じ日にイベントがある

場合に、それを拾って告知してしまう。
### 原因

`doc.xpath("//th[contains(./text(), '#{now.day}日')]/following-sibling::*")` という xpath で拾っているが `contains` は部分一致なので `6日` には `16日` `26日` なども拾ってしまう。

```
> column = doc.xpath("//th[contains(./text(), '#{now.day}日')]").text
=> "6日（木）\n\t\t\t\t\t\t\t\t\t\t16日（日）\n\t\t\t\t\t\t\t\t\t26日（水）"
```
